### PR TITLE
Added seconds to dateformat

### DIFF
--- a/auto-date.php
+++ b/auto-date.php
@@ -34,7 +34,7 @@ class AutoDatePlugin extends Plugin
     {
         $header = $event['header'];
         if (!isset($header['date'])) {
-            $header['date'] = date($this->grav['config']->get('system.pages.dateformat.default', 'H:i d-m-Y'));
+            $header['date'] = date($this->grav['config']->get('system.pages.dateformat.default', 'H:i:s d-m-Y'));
             $event['header'] = $header;
         }
     }


### PR DESCRIPTION
Alternatively, add the ability to customize the default date format through the Admin Panel plugin (long and short date formats as well). They are now based on the list defined in the blueprint. However, there is the option to edit 'system.pages.dateformat.default' directly in system.yaml, but this is not comfortable and the value is only temporary until another is selected and saved. I prefer these values: 'd.m.Y H:i:s' and 'd-m-Y H:i:s'. I will describe this in more detail in the core and thre admin issues.